### PR TITLE
Added particles/ fireworks variations and postfx. Separated class files.

### DIFF
--- a/with_classes_postfx/BallShell.pde
+++ b/with_classes_postfx/BallShell.pde
@@ -1,0 +1,40 @@
+//////// BALLSHELL ////////
+// - BallShell(float x, float y, float hue)
+// - void update()
+// - void draw()
+// - boolean readyToExplode()
+
+class BallShell extends Particle {
+  BallShell(float x, float y, float hue) {
+    pos = new PVector(x, y);
+    vel = new PVector(0, random(-12, -6));
+    acc = new PVector(0, 0.1);
+    c = color(hue, 255, 255);
+    isLaunching = true;
+  }
+  
+  void update() {
+    pos.add(vel);
+    vel.add(acc);
+    acc.mult(0);
+    
+    vel.add((random(-0.1, 0.1)), 0); // randomize a bit of the velocities
+    if (isLaunching) ballShellBrightness -= 2;
+  }
+  
+  void draw() {
+    if (isLaunching) { // before explode and still going up
+      stroke(c, ballShellBrightness); // randomize the strength of the light and draw multiple times for the glow effects
+      strokeWeight(random(5, 15));
+      point(pos.x+random(-2, 2), pos.y+random(-2, 2));
+      strokeWeight(random(4, 8)); 
+      point(pos.x+random(-2, 2), pos.y+random(-2, 2));
+      strokeWeight(random(2, 4)); 
+      point(pos.x+random(-2, 2), pos.y+random(-2, 2));
+    }
+  }
+  
+  boolean readyToExplode() {
+    return (isLaunching && vel.y > 0);
+  }
+}

--- a/with_classes_postfx/Firework.pde
+++ b/with_classes_postfx/Firework.pde
@@ -1,0 +1,71 @@
+//////// FIREWORK ////////
+// - Firework(float _x, float _y, int _fireworkCategory, int _fadeDecrement, int _particleNum)
+// - void run()
+// - boolean done()
+
+class Firework {
+  BallShell ballShell;
+  ArrayList<Particle> particles;
+  float hue;
+  int fireworkCategory;
+  int particleNum;
+  int fadeDecrement;
+
+  Firework(float _x, float _y, int _fireworkCategory, int _fadeDecrement, int _particleNum) {
+    float ballShellHue = random(40, 60);
+    fireworkCategory = _fireworkCategory;
+    particleNum = _particleNum;
+    fadeDecrement = _fadeDecrement;
+    
+    ballShell = new BallShell(_x, _y, ballShellHue);
+    particles = new ArrayList<Particle>();
+    
+//    sound.trigger();
+  }
+
+  void run() {
+    // BALL SHELL'S LIFE
+    if (ballShell != null) {
+      ballShell.applyForce(gravity);
+      ballShell.update();
+      ballShell.draw();
+      
+      // BALL SHELL EXPLODES!!!      
+      if (ballShell.readyToExplode()) {
+        // color variations and limitations by fireworkCategory(s)
+        boolean withRandomMove = false;
+        float seedParticleHue = random(360);
+        if (fireworkCategory == 1 ) seedParticleHue = random(40, 60);
+        else if (fireworkCategory == 4 ) seedParticleHue = random(40, 60);
+        else if (fireworkCategory == 5 ) withRandomMove = true;
+
+        float particleHue = seedParticleHue;
+        boolean isSpecialColors = (random(0,10) < 0.2); // rottery
+        
+        for (int i = 0; i < particleNum; i++) {
+          if (isSpecialColors) seedParticleHue = random(360);
+          particleHue = seedParticleHue + random(-10, 10);
+          if (fireworkCategory == 6 && i > (particleNum / 2)) {
+            particles.add(new Particle(ballShell.pos, random(40, 60), fadeDecrement, withRandomMove, false));            
+          } else {
+            particles.add(new Particle(ballShell.pos, particleHue, fadeDecrement, withRandomMove, true));
+          }
+        }
+        ballShell = null; // a ball shell ends its life
+      }
+    }
+
+    // PARTICLE(S)' LIFE
+    for (int i = 0; i < particles.size(); i++) {
+      Particle child = particles.get(i);
+      child.applyForce(gravity);
+      child.run();
+      if (child.isDead()) particles.remove(child);
+    }
+  }
+    
+  boolean done() { // removed if
+    return (ballShell == null && particles.isEmpty());
+  }
+
+}

--- a/with_classes_postfx/Particle.pde
+++ b/with_classes_postfx/Particle.pde
@@ -1,0 +1,92 @@
+//////// PARTICLE ////////
+// - Particle(float x, float y, float hue)
+// - Particle(PVector _pos, float hue, int fireworkCategory)
+// - void run()
+// - void update()
+// - void draw()
+// - void applyForce(PVector force)
+// - boolean isDead()
+
+class Particle {
+  PVector pos;
+  PVector vel;
+  PVector acc;
+  color c;
+
+  float ballShellBrightness = 100;
+  float particleBrightness = 60;
+  float velocityDecrement = 0.975;
+  float particleBrightnessDecrement;
+  
+  // launch state
+  boolean isLaunching = false;       // launching: true or exploded: false
+  
+  // special particle
+  boolean withRandomMove = false;    // random move
+  boolean visible = true;            // control deplayed sparkles
+  
+  Particle() { // dummy constructor for extended classes
+  }
+
+  Particle(PVector _pos, float hue, int fadeDecrement, boolean _withRandomMove, boolean _visible) {
+    withRandomMove = _withRandomMove;
+    visible = _visible;
+    pos = new PVector(_pos.x, _pos.y);
+
+    if (visible) { 
+      vel = PVector.random2D().mult(random(random(0.5, 5), 6));
+    } else {
+      // special particle (delayed sparkles) 
+      vel = PVector.random2D().mult(random(random(0.5, 4), 5));
+    }
+    
+    acc = new PVector(0, 0.1);
+    c = color(hue, 255, 255);
+    particleBrightnessDecrement = particleBrightness/random(fadeDecrement*20, fadeDecrement*40);
+  }
+
+  void run() {
+    update();
+    draw();
+  }
+  
+  void update() {
+    pos.add(vel);
+    vel.add(acc);
+    acc.mult(0);
+    vel.add((random(-0.05, 0.05)), 0); // randomize a bit of the velocities
+    
+    // Variations: random particle move
+    if (withRandomMove) vel.add(random(-0.4, 0.4), random(-0.4, 0.4));
+
+    if (!isLaunching) {
+      particleBrightness -= particleBrightnessDecrement;
+      vel.mult(velocityDecrement);
+    }
+    
+    if (!visible && particleBrightness < 20) {
+      visible = true;
+      particleBrightness = 60;
+      particleBrightnessDecrement *= 2;
+    }
+  }
+  
+  void draw() {
+    if (visible) { // experimental. toggle refresh on/off
+      stroke(c, particleBrightness);
+      strokeWeight(random(5, 10)); 
+      point(pos.x+random(-2, 2), pos.y+random(-2, 2));
+      strokeWeight(3); 
+      point(pos.x+random(-1, 1), pos.y+random(-1, 1));
+    }
+  }
+  
+  void applyForce(PVector force) {
+    acc.add(force);
+  }
+  
+  boolean isDead() {
+    return (particleBrightness < 0);
+  }
+
+}

--- a/with_classes_postfx/p5_fireworks.pde
+++ b/with_classes_postfx/p5_fireworks.pde
@@ -1,0 +1,85 @@
+import ch.bildspur.postfx.builder.*;
+import ch.bildspur.postfx.pass.*;
+import ch.bildspur.postfx.*;
+import ddf.minim.*;
+
+PostFX fx; // Bloom filter
+Minim minim;
+AudioSample sound;
+PVector gravity;
+ArrayList<Firework> fireworks;
+boolean refresh = true; // experimental: whether to refresh the screen. Toggle by "a" and "z".
+
+//////// MAIN /////////
+// - setup()
+// - draw()
+// - keyPressed()
+// - stop()
+
+void setup() {
+  // graphics
+  //size(1200, 1080);
+  //blendMode(ADD);
+  fullScreen(P2D);
+  colorMode(HSB, 360, 100, 100, 100);
+  smooth();
+  background(0);
+  fx = new PostFX(this);  
+
+  // audio
+//  minim = new Minim(this);
+//  sound = minim.loadSample("firework_sound.mp3", 2048);
+
+  // instances
+  gravity = new PVector(0.0, 0.1);
+  fireworks = new ArrayList<Firework>();
+}
+
+void draw() {
+  // refresh graphics
+  if (refresh) {
+    fill(0, random(20, 50)); // alpha for blur effects, should be aware of the performance problems
+    noStroke();
+    rect(0, 0, width, height);
+  }
+
+  // draw each Firework by loop
+  for (int i = 0; i < fireworks.size(); i++) {
+    Firework firework = fireworks.get(i);
+    firework.run();
+    if (firework.done()) {
+      fireworks.remove(firework);
+    }
+  }
+  
+  // add bloom filter
+  fx.render()
+    .bloom(0.6, 10, 10)
+    .compose();
+}
+
+void keyPressed() {
+  // define and launch firework(s). Args: x, y, category, size, particleNum
+  if (key == '1')      fireworks.add(new Firework(random(width), height, 1, 1, 200));
+  else if (key == '2') fireworks.add(new Firework(random(width), height, 2, 2, 400));
+  else if (key == '3') fireworks.add(new Firework(random(width), height, 3, 3, 600));
+  else if (key == '4') fireworks.add(new Firework(random(width), height, 4, 4, 1000));
+  else if (key == '5') fireworks.add(new Firework(random(width), height, 5, 3, 600));
+  else if (key == '6') fireworks.add(new Firework(random(width), height, 6, 3, 1000));
+
+  // experimental: interactiveness
+  else if (key == 'a') refresh = false;
+  else if (key == 'z') refresh = true;
+}
+
+void stop() {
+  // terminate audio/graphics
+  sound.close();
+  minim.stop();
+  super.stop();
+}
+
+//////// CLASSES /////////
+// - Firework: Firework consists of one BallShell and multiple Particle(s).
+// - Particle: 
+// - BallShell: BallShell extends Particle. 


### PR DESCRIPTION
以下の変更を、 `with_classes_postfx/`以下に追加しました。

- "6"キーのバリエーションを追加
- PostFXによる後処理(Bloom Filter; https://github.com/cansik/processing-postfx)を追加
  - Processing環境にライブラリの導入が必要
  - 伴ってレンダリングを `P2D` へ変更(一部エラーメッセージが出るが動作はする)
- Firework, Particle, BallShell (extends Particle)のクラスファイルを分離
- 複数のパラメータ(Particle数等)をFireworkコンストラクタの引数化
- 試験的に画面リフレッシュオンオフ("a", "z"キー)を追加

Forkからだと現存する `master` 以外へのPull Requestができず、 `karaage0703/p5_firework` にはwrite権限がなかったため、再度 `master` 宛で失礼します。